### PR TITLE
전체 상품 확인 구현

### DIFF
--- a/src/main/java/zupzup/back_end/store/controller/StoreController.java
+++ b/src/main/java/zupzup/back_end/store/controller/StoreController.java
@@ -6,7 +6,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import zupzup.back_end.store.domain.Store;
 import zupzup.back_end.store.dto.StoreDto;
+import zupzup.back_end.store.dto.response.StoreResponseDto;
 import zupzup.back_end.store.service.StoreService;
 
 @RestController
@@ -22,7 +24,7 @@ public class StoreController {
      */
 
     @GetMapping("/{storeId}")
-    public StoreDto managementMain(@PathVariable Long storeId) {
+    public StoreResponseDto managementMain(@PathVariable Long storeId) {
         // 가게 관련 내용 (가게 이름 및 운영 시간, 이벤트 내용, 오늘 할인 시간)
         // 제품 관련 내용 ([제품 이미지, 제품 이름, 가격])
         // Store 관련 DTO 전체 넘김

--- a/src/main/java/zupzup/back_end/store/domain/Store.java
+++ b/src/main/java/zupzup/back_end/store/domain/Store.java
@@ -1,9 +1,11 @@
 package zupzup.back_end.store.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.Fetch;
 import zupzup.back_end.converter.StringListConverter;
 import zupzup.back_end.store.dto.StoreDto;
 
@@ -13,6 +15,7 @@ import java.util.List;
 @Entity
 @Builder @Table(name = "store")
 @AllArgsConstructor
+@Getter
 public class Store {
 
     @Id
@@ -24,7 +27,6 @@ public class Store {
     private String loginPwd;
 
     @Column(nullable = false)
-    @Getter
     private String storeName; //가게이름
     @Column(nullable = false, length = 1000)
     private String storeAddress; //가게 주소
@@ -46,8 +48,10 @@ public class Store {
     @OneToMany(
             mappedBy = "store",
             cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
-            orphanRemoval = true
+            orphanRemoval = true,
+            fetch = FetchType.EAGER
     )
+    @JsonIgnore
     private List<Item> storeItems = new ArrayList<>();
 
     protected Store() {}

--- a/src/main/java/zupzup/back_end/store/dto/response/ItemResponseDto.java
+++ b/src/main/java/zupzup/back_end/store/dto/response/ItemResponseDto.java
@@ -1,30 +1,27 @@
-package zupzup.back_end.store.dto;
+package zupzup.back_end.store.dto.response;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.modelmapper.ModelMapper;
 import zupzup.back_end.store.domain.Item;
-import zupzup.back_end.store.domain.Store;
 
-@Getter
-@Setter
-public class ItemDto {
+@Getter @Setter
+public class ItemResponseDto {
 
     private String itemName;
     private String imageURL;
     private int itemPrice;
     private int salePrice;
     private int itemCount;
-    private Store store;
+    private Long storeId;
 
-    public ItemDto toItemDto(Item item) {
+    public ItemResponseDto toItemResponseDto(Item item) {
 
         this.itemName = item.getItemName();
         this.imageURL = item.getImageURL();
         this.itemPrice = item.getItemPrice();
         this.salePrice = item.getSalePrice();
         this.itemCount = item.getItemCount();
-        this.store = item.getStore();
+        this.storeId = item.getStore().getStoreId();
 
         return this;
     }

--- a/src/main/java/zupzup/back_end/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/zupzup/back_end/store/dto/response/StoreResponseDto.java
@@ -1,0 +1,27 @@
+package zupzup.back_end.store.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import zupzup.back_end.store.domain.Item;
+import zupzup.back_end.store.domain.Store;
+import zupzup.back_end.store.dto.ItemDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter @Setter
+public class StoreResponseDto {
+
+    private Long storeId;
+
+    private String storeName;
+    private String openTime;
+    private String endTime;
+
+    private List<String> eventList;
+
+    private String saleTimeStart;
+    private String saleTimeEnd;
+
+    private List<ItemResponseDto> storeItems = new ArrayList<>();
+}

--- a/src/main/java/zupzup/back_end/store/service/ItemService.java
+++ b/src/main/java/zupzup/back_end/store/service/ItemService.java
@@ -49,6 +49,7 @@ public class ItemService {
         itemDto.setItemPrice(requestDto.getItemPrice());
         itemDto.setSalePrice(requestDto.getSalePrice());
         itemDto.setItemCount(requestDto.getItemCount());
+        System.out.println(itemDto.getItemCount());
         Store store = storeRepository.findById(requestDto.getStoreId())
                 .orElseThrow(EntityNotFoundException::new);
         itemDto.setStore(store);
@@ -60,23 +61,23 @@ public class ItemService {
         item.saveItem(itemDto);
 
         itemRepository.save(item);
+        System.out.println(item.getItemCount());
 
         return item.getItemId();
     }
 
+    @Transactional
     public void deleteItem(Long itemId) {
         /**
          * 상품 삭제
-         * param : itemId & storeId
+         * param : itemId
          * return : void
          */
 
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(EntityNotFoundException::new);
 
-        if(item == null) {
-            throw new EntityNotFoundException();
-        } else itemRepository.deleteById(itemId);
+        itemRepository.deleteById(itemId);
     }
 
     @Transactional
@@ -110,11 +111,12 @@ public class ItemService {
             if(itemImg != null) {
                 String imageURL = s3Uploader.upload(itemImg, store.getStoreName());
                 updateDto.setImageURL(imageURL);
+            } else {
+                updateDto.setImageURL("");
             }
 
             //modelMapper.map(updateDto, itemEntity);
             itemEntity.updateItem(updateDto);
-            System.out.println(itemEntity.getItemCount());
 
             return 0;
         } catch (IOException e) {

--- a/src/main/java/zupzup/back_end/store/service/S3Uploader.java
+++ b/src/main/java/zupzup/back_end/store/service/S3Uploader.java
@@ -40,7 +40,7 @@ public class S3Uploader {
     }
 
     private String upload(File uploadFile, String dirName) {
-        String fileName = dirName + "/" + uploadFile.getName();
+        String fileName = dirName + "/" + UUID.randomUUID() + uploadFile.getName();
         String uploadImageUrl = putS3(uploadFile, fileName);
 
         removeNewFile(uploadFile); // 로컬에 생서된 File 삭제

--- a/src/main/java/zupzup/back_end/store/service/StoreService.java
+++ b/src/main/java/zupzup/back_end/store/service/StoreService.java
@@ -9,10 +9,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zupzup.back_end.store.domain.Item;
 import zupzup.back_end.store.domain.Store;
+import zupzup.back_end.store.dto.ItemDto;
 import zupzup.back_end.store.dto.StoreDto;
+import zupzup.back_end.store.dto.response.ItemResponseDto;
+import zupzup.back_end.store.dto.response.StoreResponseDto;
 import zupzup.back_end.store.repository.ItemRepository;
 import zupzup.back_end.store.repository.StoreRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -24,27 +28,39 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final ItemService itemService;
     private final ItemRepository itemRepository;
-    @Autowired
-    ModelMapper modelMapper;
 
     // 가게 저장
 
-    // 상품 리스트
-    public List<Item> itemList(StoreDto storeDto) {
-
-        List<Item> itemList = storeDto.getStoreItems();
-        return itemList;
-    }
-
     // 가게 메인 페이지
-    public StoreDto mainPage(Long storeId) {
+    public StoreResponseDto mainPage(Long storeId) {
 
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(EntityNotFoundException::new);
+        // 가게 관련 내용 (가게 이름 및 운영 시간, 이벤트 내용, 오늘 할인 시간)
+        // 제품 관련 내용 ([제품 이미지, 제품 이름, 가격])
 
-        StoreDto storeDto = new StoreDto();
-        modelMapper.map(store, storeDto);
+        Store store = storeRepository.findById(storeId).get();
+        StoreResponseDto responseDto = new StoreResponseDto();
 
-        return storeDto;
+        // 엔티티->Dto
+        responseDto.setStoreId(store.getStoreId());
+        responseDto.setStoreName(store.getStoreName());
+        responseDto.setOpenTime(store.getOpenTime());
+        responseDto.setEndTime(store.getEndTime());
+        responseDto.setEventList(store.getEventList());
+        responseDto.setSaleTimeStart(store.getSaleTimeStart());
+        responseDto.setSaleTimeEnd(store.getSaleTimeEnd());
+
+        // 아이템 가져오기 및 저장
+        List<Item> itemList = itemRepository.findAllByStore(store);
+        List<ItemResponseDto> itemDtoList = new ArrayList<>();
+
+        for(Item item : itemList) {
+
+            ItemResponseDto itemDto = new ItemResponseDto();
+            itemDtoList.add(itemDto.toItemResponseDto(item));
+        }
+
+        responseDto.setStoreItems(itemDtoList);
+
+        return responseDto;
     }
 }


### PR DESCRIPTION
## 변경사항 💡

1. 전체 상품 확인 기능
- 상품과 가게 정보를 확인할 수 있는 기능을 구현하였습니다.
- 가게 엔티티에 화면상 필요없는 컬럼들이 많아 새로 responseDto를 생성하여 만들었습니다. 아이템 또한 화면에 필요한 정보들로만 구성하였습니다.

2. 이미지 이름 변동
- 이미지 저장 시 같은 이름이라도 다른 이름으로 저장되도록 변경하였습니다.

<br>

## 스크린샷 📸

1-1. 아무것도 저장하지 않았을시의 모습
<img width="1148" alt="스크린샷 2023-01-29 오후 5 02 42" src="https://user-images.githubusercontent.com/77785750/215313711-b3e06798-534c-4119-b4c0-7325e440f1f6.png">
1-2. 상품 2개 넣었을 경우 + 이미지 이름 다름
<img width="1148" alt="스크린샷 2023-01-29 오후 5 03 01" src="https://user-images.githubusercontent.com/77785750/215313708-2d9ad0fc-5124-47a3-baa8-6992d2c10749.png">

<br>

## 진행해야 할 사항 ⭐️

1. 현재 상품 삭제가 되지 않습니다. 이를 수정해야 할 듯 합니다.
2. 추가적으로 상품에 필요한 내용 있으면 의견 부탁드립니다!

<br>

## 리뷰어에게 할 말 🤔

현재 사장님 메인화면 기능들이 완료되어 갑니다. 필요시 리팩토링 및 코드 수정을 진행하려 합니다.
더 필요한 기능 있으면 말씀 부탁드립니다.

<br>
