### PR TITLE
Entity check

### DIFF
--- a/domain-module/src/main/java/domain/order/Order.java
+++ b/domain-module/src/main/java/domain/order/Order.java
@@ -6,6 +6,7 @@ import domain.store.Store;
 import dto.order.OrderDto;
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.hibernate.annotations.Cascade;
 
 
 import java.util.List;
@@ -32,6 +33,7 @@ public class Order {
 
     @ElementCollection
     @CollectionTable(name = "orderSpecific", joinColumns = @JoinColumn(name="orderId", referencedColumnName="orderId"))
+    @Cascade(org.hibernate.annotations.CascadeType.ALL)
     private List<OrderSpecific> orderList;  // 주문 품목(이름, 가격, 개수, (img)
 
     public void addOrder(OrderDto orderDto) {


### PR DESCRIPTION
## 🔍 개요
+ close #30

## 📝 작업사항
1. orderSpecific table에서 order를 참조할 때 사용하는 외래키의 column 명을 "orderId(ORDER_ID)"로 지정해주었습니다. 기존 DB에서는 "ORDER_ORDER_ID"로 나왔었습니다.
2. orderSpecific table에 CASCADE 옵션(영속성 전이)을 주었습니다.


## 📸 스크린샷 또는 영상
1 & 2
![image](https://user-images.githubusercontent.com/64959985/221491698-adae8c5b-2ff4-431b-ac5c-0fbc75dbaa06.png)




## 🧐 참고 사항

## 📄 Reference
[]()
