### PR TITLE
Dependency clean

### DIFF
--- a/application-module/application-common/build.gradle
+++ b/application-module/application-common/build.gradle
@@ -3,7 +3,3 @@ plugins {
     id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.1.0'
 }
-
-group = 'zupzup'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'

--- a/application-module/build.gradle
+++ b/application-module/build.gradle
@@ -4,11 +4,11 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
-group = 'zupzup'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+subprojects {   // Applied to application-common, seller, customer
+    group = 'zupzup'
+    version = '0.0.1-SNAPSHOT'
+    sourceCompatibility = '17'
 
-subprojects {
     dependencies {
         implementation(project(":core-module"))
         implementation(project(":domain-module"))

--- a/application-module/customer/build.gradle
+++ b/application-module/customer/build.gradle
@@ -3,7 +3,3 @@ plugins {
     id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.1.0'
 }
-
-group = 'zupzup'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'

--- a/application-module/seller/build.gradle
+++ b/application-module/seller/build.gradle
@@ -3,7 +3,3 @@ plugins {
     id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.1.0'
 }
-
-group = 'zupzup'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ subprojects {	// 모든 하위 모듈에 적용되는 setting
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
 
+	group = 'zupzup'
+	version = '0.0.1-SNAPSHOT'
+	sourceCompatibility = '17'
+
 	repositories{
 		mavenCentral()
 	}
@@ -43,7 +47,6 @@ subprojects {	// 모든 하위 모듈에 적용되는 setting
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
 		testImplementation 'junit:junit:4.13.2'
 
-		testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	}
 
 	test {
@@ -51,8 +54,6 @@ subprojects {	// 모든 하위 모듈에 적용되는 setting
 	}
 }
 project(':core-module') {	// 공통 코드 모듈
-	dependencies {
-	}
 	bootJar {	// 단독으로 실행되지 않으므로, 해당 모듈 라이브러리화 필요
 		enabled = false
 	}

--- a/core-module/build.gradle
+++ b/core-module/build.gradle
@@ -3,7 +3,3 @@ plugins {
     id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.1.0'
 }
-
-group = 'zupzup'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'

--- a/domain-module/build.gradle
+++ b/domain-module/build.gradle
@@ -3,7 +3,3 @@ plugins {
     id 'org.springframework.boot' version '3.0.0'
     id 'io.spring.dependency-management' version '1.1.0'
 }
-
-group = 'zupzup'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'


### PR DESCRIPTION
## 🔍 개요
+ close #38 

## 📝 작업사항
- module들의 dependency를 정리 및 정리 후 테스트했습니다. 필요없는 중복, 추후의 의존성 추가 시 헷갈림을 방지하기 위한 작업입니다. 완전히 정리된 건 아니므로, 추후에도 정리가 필요할 것 같습니다.


## 📸 스크린샷 또는 영상
![image](https://user-images.githubusercontent.com/64959985/223349456-f14c7222-2e0d-4a78-b280-e4f7de085ed8.png)
application-module의 build.gradle이 가장 많이 변경되어 해당 부분만 스크린샷 및 설명 첨부합니다. application-module 내의 application-common, seller, customer의 build.gradle을 하나에 정리해뒀다고 생각하시면 편하실 겁니다. root(ZupZup_backend) module의 build.gradle과 비슷하게, application-module도 내부에 여러 모듈을 가지므로 root module의 build.gradle과 유사한 모습을 보이게 됐습니다.  
앞으로 root, application-module과 같은 부모(?) module의 build.gradle에서 의존성 및 버전 정리를 수행해주시면 되겠습니다.


## 🧐 참고 사항

## 📄 Reference
[]()
