### PR TITLE
response body 수정

### DIFF
--- a/application-module/seller/src/main/java/com/rest/api/store/controller/ItemController.java
+++ b/application-module/seller/src/main/java/com/rest/api/store/controller/ItemController.java
@@ -25,8 +25,9 @@ public class ItemController {
     public ResponseEntity saveItem(@RequestPart(value = "item") ItemRequestDto requestDto,
                                    @RequestPart(value = "image", required = false) MultipartFile itemImg) throws Exception {
 
-        Long itemId = itemService.saveItem(requestDto, itemImg);
-        return new ResponseEntity(itemId, HttpStatus.CREATED); // 상품의 id 반환
+        String itemName = itemService.saveItem(requestDto, itemImg);
+        String format = String.format("상품 %s(이)가 저장되었습니다.", itemName);
+        return new ResponseEntity(format, HttpStatus.CREATED); // 상품의 이름 반환
     }
 
     @PutMapping("/{storeId}/{itemId}")

--- a/application-module/seller/src/main/java/com/rest/api/store/service/ItemService.java
+++ b/application-module/seller/src/main/java/com/rest/api/store/service/ItemService.java
@@ -31,7 +31,7 @@ public class ItemService {
     ModelMapper modelMapper;
 
     @Transactional
-    public Long saveItem(ItemRequestDto requestDto, MultipartFile itemImgFile) throws Exception {
+    public String saveItem(ItemRequestDto requestDto, MultipartFile itemImgFile) throws Exception {
         /**
          * 상품 등록
          * param: itemDto & multipartFile
@@ -58,7 +58,7 @@ public class ItemService {
         //3. 상품 저장
         itemRepository.save(item);
 
-        return item.getItemId();
+        return item.getItemName();
     }
 
     @Transactional


### PR DESCRIPTION
## 🔍 개요
* #62 

## 📝 작업사항
- itemController 및 itemService 수정
상품 업데이트, 삭제 및 목록의 responseBody는 수정되지 않아도 내용 전달이 충분한 것 같아 상품 저장의 responseBody만 수정했습니다.
원래 저장된 item의 id만 반환하는 것에서 item의 이름을 service 에서 반환하고 "상품 %s(이)가 저장되었습니다."를 controller에서 반환하도록 만들었습니다.

## 📸 스크린샷 또는 영상

<p>
  <img src="https://user-images.githubusercontent.com/77785750/226903556-b3ea2d27-02e5-4541-a0a5-f6bd74ee2da3.png" width="500">
</p>
아이템 저장시 볼 수 있는 response
<p>
 <img src="https://user-images.githubusercontent.com/77785750/226903564-6ca30c2d-cd7e-4114-a891-2eb40fced2cf.png" width="500>
</p>
수정된 코드

## 🧐 참고 사항

## 📄 Reference
[]()
