### PR TITLE
Get uri to input stream

### DIFF
--- a/application-module/customer/src/main/java/com/rest/api/auth/jwt/JwtTokenProvider.java
+++ b/application-module/customer/src/main/java/com/rest/api/auth/jwt/JwtTokenProvider.java
@@ -126,13 +126,10 @@ public class JwtTokenProvider {
                     .signWith(SignatureAlgorithm.ES256, getPrivateKey())
                     .compact();
         } catch(IOException e) {
-            System.out.println("IOException" + e);
             return null;
         } catch(NoSuchAlgorithmException e) {
-            System.out.println("NoSuch" + e);
             return null;
         } catch(InvalidKeySpecException e) {
-            System.out.println("Invalid" + e);
             return null;
         }
 


### PR DESCRIPTION
## 🔍 개요
+ #109 

## 📝 작업사항
테스트 서버에서 회원탈퇴 시, jar 압축과정에서 파일의 path가 변경되어 읽어오지 못하는 현상이 발견됐습니다. 이를 고치기 위해 getURI() 방식에서 getInputStream()방식으로의 수정이 있었습니다. 관련 내용 스크린샷과 링크 첨부하겠습니다.


## 📸 스크린샷 또는 영상
<img width="986" alt="image" src="https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/50a4e4f8-eb0d-4e70-9f8b-a809864d1384">
How To Join in Java라는 사이트에서 read a file from resources 섹션에서 발견한 설명입니다.  

<img width="1190" alt="image" src="https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/d7f0fb0d-c564-484e-b853-d43e4f9e97b7">
그로 인해 표시한 것처럼의 메서드 변경이 있었습니다. 로컬에서는 getURI()를 사용할 때와 마찬가지로 파일을 읽어오는 것을 확인했으며, 머지 후 서버에서 바로 테스트해볼 예정입니다.


## 🧐 참고 사항

## 📄 Reference
[Read a File from Resources in Spring Boot](https://howtodoinjava.com/spring-boot2/read-file-from-resources/)
