### PR TITLE
Order - 확정 주문에 대한 요청(취소, 완료)

### DIFF
--- a/application-module/seller/src/main/java/com/rest/api/order/controller/OrderController.java
+++ b/application-module/seller/src/main/java/com/rest/api/order/controller/OrderController.java
@@ -51,9 +51,10 @@ public class OrderController {
     }
 
     @PatchMapping("/{orderId}/complete")
-    public ResponseEntity completeOrder() {
+    public ResponseEntity completeOrder(@PathVariable Long storeId, @PathVariable Long orderId, @RequestBody @Valid OrderRequestDto.PatchOrderDto patchOrderDto) {
+        OrderResponseDto.PatchOrderResponseDto completeOrderDto = orderService.completeOrder(storeId, orderId, patchOrderDto);
 
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity(completeOrderDto, HttpStatus.OK);
     }
 
 }

--- a/domain-module/src/main/java/domain/item/Item.java
+++ b/domain-module/src/main/java/domain/item/Item.java
@@ -47,7 +47,7 @@ public class Item {
             this.store = itemDto.getStore();
         }
 
-    // 상품 개수 변경(사장님이 예약 확정 시) -> setter로 갈지 이 함수로 갈지는 나중에 결정.
+    // 상품 개수 변경(사장님이 예약 확정, 완료 시)
         public void updateItemCount(ItemDto.getDtoWithStore itemDto) {
             this.itemCount = itemDto.getItemCount();
         }


### PR DESCRIPTION
## 🔍 개요
+ close #138  

## 📝 작업사항
확정 된 주문에 대해 사장님이 취소, 완료 요청을 했을 때의 로직을 재정의 했습니다. 기존에는 주문의 Patch 요청에 대해 모두 하나의 url로 받아 안에서 분기처리를 했으나, 신규 주문과 확정 주문의 처리를 나누면서 생기게 된 파트입니다. 동작은 간단히 CANCEL, COMPLETE에 대한 확인을 통해 그에 적절한 행동을 취합니다. 스크린샷을 통해 보겠습니다.


## 📸 스크린샷 또는 영상
1. Controller
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/f5657cdd-4e00-45bd-89a2-1ee4ccbcb1cc)
url 엔드포인트가 추가됐습니다. 기존에는 orderId로 끝났지만, 그 뒤에 complete을 달아주어 주문의 최종 완료 시 보내는 api임을 명시했습니다. 

2. orderService - 전체
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/2922a4a6-40a8-4642-a29a-c986e37b46d2)
확정 주문에 대한 처리를 수행하는 orderService인 completeOrder입니다. 요청으로 들어온 orderStatus가 CANCEL인지 COMPLETE인지에 따른 분기처리를 수행했습니다. 

2-1. orderService - CANCEL일 떄
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/f40e21a3-a050-4c9f-bafc-3aee7b319d23)
CANCEL일 떄는 Enttiy의 상태만 바꾸는 것이 아니라 주문 확정 때 차감했던 상품의 재고를 다시 늘려주는 로직이 있습니다. 조건문 안의 내용이 그것입니다. 이떄 쓰인 updateItemStock 함수를 한 번 보시겠습니다.
2-1-1. updateItemStock()
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/53d9ac92-23ad-4456-a580-56097ce5098a)
여기서는 반복문을 통해 orderList 내부의 모든 아이템에 대한 개수 변경을 수행합니다. 클라이언트에서 요청한 개수와 원래 개수를 조합하여 최종 DB에 저장될 값을 정해주는 로직이라고 생각하시면 됩니다.

2-2. orderService - COMPLETE일 떄
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/39c211b3-dfa9-46a1-a015-678f0376ba61)
이 경우는 딱히 특별한 것 없이 상태만 저장, 그 후 responseDto를 controller에 리턴해줍니다.

## 🧐 참고 사항
이 파일 안의 ItemDto 관련해서는(line 183~190) 우선 현정님이 구현해놓으신 부분이 있어 나중에 혼란을 야기하지 않기 위해 우선은 가져다 썼으나, 추후에 name 수정 등이 필요해보이긴 합니다. 관련해서 말씀나눠보면 좋을 것 같습니다.

## 📄 Reference
[]()
