### PR TITLE
Order fix

### DIFF
--- a/application-module/seller/src/main/java/com/rest/api/order/controller/OrderController.java
+++ b/application-module/seller/src/main/java/com/rest/api/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.rest.api.order.controller;
 
+import domain.order.type.OrderStatus;
 import dto.order.seller.request.OrderRequestDto;
 import dto.order.seller.response.OrderResponseDto;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -54,46 +55,46 @@ public class OrderController {
     // <-------------------- PATCH part -------------------->
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "주문 취소 성공",
-                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderStatusResponseDto.class)))
+                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderResponseDto.class)))
     })
     @PatchMapping("/new-order/{orderId}/cancel")  // 신규 주문 취소 시
-    public ResponseEntity updateOrder(@PathVariable Long storeId, @PathVariable Long orderId, @RequestBody @Valid OrderRequestDto.PatchOrderDto patchOrderDto) {
-        OrderResponseDto.PatchOrderStatusResponseDto patchOrderStatusResponseDto = orderService.cancelNewOrder(storeId, orderId/*, patchOrderDto*/);
+    public ResponseEntity cancelNewOrder(@PathVariable Long storeId, @PathVariable Long orderId) {
+        OrderResponseDto.PatchOrderResponseDto patchOrderStatusResponseDto = orderService.updateOrderStatus(storeId, orderId, OrderStatus.CANCEL);
 
         return new ResponseEntity(patchOrderStatusResponseDto, HttpStatus.OK); // patch 된 order의 dto 반환
     }
 
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "주문 확정 성공",
-//                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderResponseDto.class)))
-//    })
-//    @PatchMapping("/new-order/{orderId}/confirm")  // 신규 주문 확정 시
-//    public ResponseEntity updateOrder(@PathVariable Long storeId, @PathVariable Long orderId, @RequestBody @Valid OrderRequestDto.PatchOrderDto patchOrderDto) {
-//        OrderResponseDto.PatchOrderResponseDto patchOrderResponseDto = orderService.confirmOrder(storeId, orderId, patchOrderDto);
-//
-//        return new ResponseEntity(patchOrderResponseDto, HttpStatus.OK); // patch 된 order의 dto 반환
-//    }
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주문 확정 성공",
+                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderResponseDto.class)))
+    })
+    @PatchMapping("/new-order/{orderId}/confirm")  // 신규 주문 확정 시
+    public ResponseEntity confirmNewOrder(@PathVariable Long storeId, @PathVariable Long orderId) {
+        OrderResponseDto.PatchOrderResponseDto patchOrderResponseDto = orderService.updateOrderData(storeId, orderId, OrderStatus.CONFIRM);
+
+        return new ResponseEntity(patchOrderResponseDto, HttpStatus.OK); // patch 된 order의 dto 반환
+    }
 
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "주문 취소 성공",
-                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderDataResponseDto.class)))
+                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderResponseDto.class)))
     })
     @PatchMapping("/confirmed-order/{orderId}/cancel")    // 확정 주문 취소 시
-    public ResponseEntity completeOrder(@PathVariable Long storeId, @PathVariable Long orderId, @RequestBody @Valid OrderRequestDto.PatchOrderDto patchOrderDto) {
-        OrderResponseDto.PatchOrderDataResponseDto completeOrderDto = orderService.completeOrder(storeId, orderId, patchOrderDto);
+    public ResponseEntity cancelConfirmedOrder(@PathVariable Long storeId, @PathVariable Long orderId) {
+        OrderResponseDto.PatchOrderResponseDto completeOrderDto = orderService.updateOrderData(storeId, orderId, OrderStatus.CANCEL);
 
         return new ResponseEntity(completeOrderDto, HttpStatus.OK);
     }
 
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200", description = "주문 완료 성공",
-//                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderResponseDto.class)))
-//    })
-//    @PatchMapping("/confirmed-order/{orderId}/complete")  // 확정 주문 완료 시
-//    public ResponseEntity updateOrder(@PathVariable Long storeId, @PathVariable Long orderId, @RequestBody @Valid OrderRequestDto.PatchOrderDto patchOrderDto) {
-//        OrderResponseDto.PatchOrderResponseDto patchOrderResponseDto = orderService.confirmOrder(storeId, orderId, patchOrderDto);
-//
-//        return new ResponseEntity(patchOrderResponseDto, HttpStatus.OK); // patch 된 order의 dto 반환
-//    }
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "주문 완료 성공",
+                    content = @Content(schema = @Schema(implementation = OrderResponseDto.PatchOrderResponseDto.class)))
+    })
+    @PatchMapping("/confirmed-order/{orderId}/complete")  // 확정 주문 완료 시
+    public ResponseEntity completeConfirmedOrder(@PathVariable Long storeId, @PathVariable Long orderId) {
+        OrderResponseDto.PatchOrderResponseDto patchOrderStatusResponseDto = orderService.updateOrderStatus(storeId, orderId, OrderStatus.COMPLETE);
+
+        return new ResponseEntity(patchOrderStatusResponseDto, HttpStatus.OK); // patch 된 order의 dto 반환
+    }
 
 }

--- a/domain-module/src/main/java/dto/order/seller/request/OrderRequestDto.java
+++ b/domain-module/src/main/java/dto/order/seller/request/OrderRequestDto.java
@@ -9,12 +9,4 @@ import java.util.List;
 
 public class OrderRequestDto {
 
-    // <-------------------- PATCH part -------------------->
-    @Getter
-    @Setter
-    public static class PatchOrderDto {
-        private OrderStatus orderStatus;
-        private List<OrderSpecific> orderList; // 주문 품목 이름, 가격, 개수
-    }
-
 }

--- a/domain-module/src/main/java/dto/order/seller/response/OrderResponseDto.java
+++ b/domain-module/src/main/java/dto/order/seller/response/OrderResponseDto.java
@@ -39,14 +39,7 @@ public class OrderResponseDto {
     // <-------------------- PATCH part -------------------->
     @Getter
     @Setter
-    public static class PatchOrderDataResponseDto { // PATCH 시 return 할 DTO(신규 주문 확정, 확정 주문 취소 시에만 사용)
-        private GetOrderDetailsDto data;
-        private String message;
-    }
-
-    @Getter
-    @Setter
-    public static class PatchOrderStatusResponseDto {
+    public static class PatchOrderResponseDto { // PATCH 시 return 할 DTO(신규 주문 확정, 확정 주문 취소 시에만 사용)
         private GetOrderDetailsDto data;
         private String message;
     }


### PR DESCRIPTION
## 🔍 개요
+ close #147 

## 📝 작업사항
사장님 앱의 주문 처리 api가 원래는 신규 주문/확정 주문으로만 나뉘었고, 요청 시 바디에 orderStatus를 넘겨받아 분기처리를 하는 로직이었습니다. 하지만 영진님과 상의한 결과 부적절하다는 판단하에 api를 총 4가지,
1. 신규 주문에 대한 취소
2. 신규 주문에 대한 확정
3. 확정 주문에 대한 취소
4. 확정 주문에 대한 완료
로 나누게 되었습니다.

## 📸 스크린샷 또는 영상
1-1. Controller들 - 신규 주문
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/a2541c25-695b-4494-9561-c7daea333fbb)
1-2. Controller들 - 확정 주문
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/d004663a-12c8-4def-8b08-f7a3d3022e7a)

상태만 바뀌는 api인 신규 주문에 대한 취소, 확정 주문에 대한 완료는 orderService의 updateOrderStatus()함수를 통해 처리됩니다.
아이템 재고까지 바뀌는 api인 신규 주문에 대한 확정, 확정 주문에 대한 취소는 orderService의 updateOrderData()함수를 통해 처리됩니다.

2-1. Service - updateOrderStatus(상태만 변경되는), updateOrderData(아이템 재고까지 변경되는) 
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/df45231f-16cc-4959-8336-7a9f080706ef)
두 함수는 내부에 있는 코드가 중복되는 곳이 많습니다. 그래서 하나로 합치려고 봤더니 CANCEL건에 대해 신규 주문의 CANCEL인지 확정 주문의 CANCEL인지를 분류할 수 있는 방법이 떠오르지 않아 우선 두 함수로 나누어 처리했습니다. 두 함수는 각각 updateOrderAndReturn(), updateOrderDataAndReturn() 함수를 호출합니다.  

2-2.
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/ce3e9402-dd8f-43a2-865f-93f2226cf200)
updateOrderAndReturn()은 updateOrderDataAndReturn()에 포함됩니다. updateOrderAndReturn은 db에 바뀐 내용을 저장 및 return할 dto를 만드는 역할, updateOrderDataAndReturn()은 아이템 재고관리까지 하는 함수입니다.


## 🧐 참고 사항
예상치 못한 문제로 인해 금일 마무리하려했던 로그인 마무리는 내일까지로 미루어질 것으로 보입니다. 참고 바랍니다.

## 📄 Reference
[]()
