### PR TITLE
사장님 앱 - 인증 관련 status code 수정(아이디를 통한 로그인 시 )

### DIFF
--- a/application-module/seller/src/main/java/com/rest/api/advice/SellerControllerAdvice.java
+++ b/application-module/seller/src/main/java/com/rest/api/advice/SellerControllerAdvice.java
@@ -42,7 +42,7 @@ public class SellerControllerAdvice {
 
     @ExceptionHandler(value = NoSellerPresentsException.class)
     public ResponseEntity noUserPresents(NoSellerPresentsException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 
     @ResponseStatus(value = HttpStatus.NOT_FOUND)   // 가게, 주문이 존재하지 않는 경우


### PR DESCRIPTION
## 🔍 개요
+ close #171 

## 📝 작업사항
사장님 앱에서 아이디 비밀번호를 통한 로그인 시 status code를 수정했습니다. 아이디가 잘못된 경우, 자원을 데이터베이스에서 찾을 수 없다는 의미로 404를 리턴하도록수정하였습니다. 비밀번호가 잘못된 경우는 token들의 유효성 검증 실패의 경우와 분리하기 위해 403을 리턴하도록 수정하였습니다.  
이 과정에서 아이디가 잘못된 경우의 체크에 대해 try / catch가 아닌, 조건문을 통해 데이터 객체 null 여부 체크로 변경하였습니다.


## 📸 스크린샷 또는 영상
1. status코드 변경은 단순 status code만 변경이므로 스크린샷 생략하겠습니다.
2. 변경된 ID 검증 로직
<img width="880" alt="image" src="https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/09927fd5-6bda-403a-b6a4-4d093c9c24d0">
표시한 바와 같이 조건문 한 줄로 처리를 하도록 변경했습니다.

## 🧐 참고 사항

## 📄 Reference
[]()
