### PR TITLE
사용자 앱 - 유저 정보 반환 API 구현, 중복 코드 리팩터

### DIFF
--- a/application-module/customer/src/main/java/com/rest/api/info/controller/InfoController.java
+++ b/application-module/customer/src/main/java/com/rest/api/info/controller/InfoController.java
@@ -7,6 +7,7 @@ import dto.MessageDto;
 import dto.info.customer.request.PatchNickNameDto;
 import dto.info.customer.request.PatchOptionalTermDto;
 import dto.info.customer.request.PatchPhoneNumberDto;
+import dto.info.customer.response.GetInfoResponseDto;
 import dto.info.customer.response.PatchInfoResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,6 +31,27 @@ public class InfoController {
 
     private final InfoService infoService;
 
+    // <-------------------- GET part -------------------->
+    @Operation(summary = "유저의 정보 반환", description = "유저의 정보 반환 요청")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "유저 정보 반환 성공",
+                    content = @Content(schema = @Schema(implementation = GetInfoResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "요청에 필요한 헤더(액세스 토큰)가 없음",
+                    content = @Content(schema = @Schema(example = "Required header parameter(accessToken) does not exits"))),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 만료",
+                    content = @Content(schema = @Schema(example = "redirect: /mobile/sign-in/refresh (Access token expired. Renew it with refresh token.)"))),
+            @ApiResponse(responseCode = "401", description = "로그아웃 혹은 회원탈퇴한 회원의 액세스 토큰",
+                    content = @Content(schema = @Schema(example = "Sign-outed or deleted user. Please sign-in or sign-up again.")))
+    })
+    @GetMapping("")
+    public ResponseEntity getUserInfo(@Parameter(name = "accessToken", description = "액세스 토큰", in = ParameterIn.HEADER) @RequestHeader(JwtTokenProvider.ACCESS_TOKEN_NAME) String accessToken) {
+        GetInfoResponseDto userInfoDto = infoService.getUserInfo(accessToken);
+
+        return new ResponseEntity(userInfoDto, HttpStatus.OK);
+    }
+
+
+    // <-------------------- PATCH part -------------------->
     @Operation(summary = "전화번호 수정", description = "유저의 전화번호 수정 요청")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "전화번호 변경 성공",

--- a/application-module/customer/src/main/java/com/rest/api/info/service/InfoService.java
+++ b/application-module/customer/src/main/java/com/rest/api/info/service/InfoService.java
@@ -6,6 +6,7 @@ import dto.auth.customer.UserDto;
 import dto.info.customer.request.PatchNickNameDto;
 import dto.info.customer.request.PatchOptionalTermDto;
 import dto.info.customer.request.PatchPhoneNumberDto;
+import dto.info.customer.response.GetInfoResponseDto;
 import dto.info.customer.response.PatchInfoResponseDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,16 @@ public class InfoService {
     private final UserRepository userRepository;
     private final AuthUtils authUtils;
 
+    // <-------------------- GET part -------------------->
+    public GetInfoResponseDto getUserInfo(String accessToken) {
+        User userEntity = authUtils.getUserEntity(accessToken); // 액세스 토큰을 이용하여 유저 정보 반환
+        UserDto userDto = modelMapper.map(userEntity, UserDto.class);
+        GetInfoResponseDto userInfoDto = new GetInfoResponseDto(userDto, "Get user data succeed.");
+
+        return userInfoDto;
+    }
+
+    // <-------------------- PATCH part -------------------->
     public PatchInfoResponseDto updatePhoneNumber(String accessToken, PatchPhoneNumberDto patchPhoneNumberDto) {
         User userEntity = authUtils.getUserEntity(accessToken); // 액세스 토큰을 이용하여 유저 정보 반환
         userEntity.updatePhoneNumber(patchPhoneNumberDto);    // 전화번호 변경

--- a/domain-module/src/main/java/dto/info/customer/response/GetInfoResponseDto.java
+++ b/domain-module/src/main/java/dto/info/customer/response/GetInfoResponseDto.java
@@ -1,0 +1,22 @@
+package dto.info.customer.response;
+
+import dto.auth.customer.UserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class GetInfoResponseDto {
+
+    @Schema(description = "변경된 유저의 정보", implementation = UserDto.class)
+    private UserDto data;
+
+    @Schema(description = "처리 결과 메세지")
+    private String message;
+
+}


### PR DESCRIPTION
## 🔍 개요
+ close  #183 
+ close #182 

## 📝 작업사항
안녕하십니까!!!!!!!!!!!!!!
사용자 정보를 반환하는 api를 구현했습니다. 그와 더불어 기존 정보 관련 서비스에 중복적으로 작성돼있던 부분을, authUtils에 선언된 함수 호출로 변경하여 코드 라인을 줄였습니다.

## 📸 스크린샷 또는 영상
1. 사용자 정보 반환의 controller
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/95c5915e-5f0c-4f33-b75f-c6ee418768c8)

2. 사용자 정보 반환의 service
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/33160689-f6a8-48d8-a705-43a4b90fdf62)
서비스 스크린샷에서는 util를 사용하여 리팩터한 부분의 설명도 드리겠습니다. 맨 첫줄에 보이는 authUtils.getUserEntity() 함수를 이용하여 jwtTokenProvider의 accessToken을 통해 providerUserId를 가져오는 함수, providerUserId를 통해 userEntity를 가져오는 함수의 중복 작성을 줄였습니다. 쉬운 내용이지만 변경된 부분이기에 한 번은 언급해야할 것 같았습니다.

3. 반환되는 사용자 정보 예시
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/ba6857f3-80fa-40b4-b34c-049493a9218f)


## 🧐 참고 사항

## 📄 Reference
[]()
