### PR TITLE
사용자 앱 - refresh 시 response body에서 user entity 삭제

### DIFF
--- a/application-module/customer/src/main/java/com/rest/api/auth/controller/MobileOAuthController.java
+++ b/application-module/customer/src/main/java/com/rest/api/auth/controller/MobileOAuthController.java
@@ -125,7 +125,8 @@ public class MobileOAuthController {
     @Operation(summary = "로그인(리프레시 토큰 유효 시)", description = "리프레시 토큰을 이용한 액세스 토큰 갱신")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "액세스 토큰 갱신 성공",
-                    headers = {@Header(name = JwtTokenProvider.ACCESS_TOKEN_NAME, description = "액세스 토큰")},
+                    headers = {@Header(name = JwtTokenProvider.ACCESS_TOKEN_NAME, description = "액세스 토큰"),
+                            /* @Header(name = JwtTokenProvider.REFRESH_TOKEN_NAME, description = "리프레시 토큰") */},
                     content = @Content(schema = @Schema(implementation = CustomerRefreshResultDto.class))),
             @ApiResponse(responseCode = "400", description = "요청에 필요한 헤더(리프레시 토큰)가 없음",
                     content = @Content(schema = @Schema(example = "Required request header 'refreshToken' for method parameter type String is not present"))),
@@ -134,10 +135,11 @@ public class MobileOAuthController {
     })
     @PostMapping("/sign-in/refresh")    // 로그인 요청(access token 만료, refresh token 유효할 경우), refresh token만 받아옴
     public ResponseEntity signInWithRefreshToken(@Parameter(name = JwtTokenProvider.REFRESH_TOKEN_NAME, description = "리프레시 토큰", in = ParameterIn.HEADER) @RequestHeader(JwtTokenProvider.REFRESH_TOKEN_NAME) String refreshToken) {
-        CustomerTokenInfoDto refreshResult = mobileOAuthService.signInWithRefreshToken(refreshToken);
+        CustomerRefreshResultDto refreshResult = mobileOAuthService.signInWithRefreshToken(refreshToken);
         if (refreshResult.getResult().equals(jwtTokenProvider.SUCCESS_STRING)) {    // Refresh token 유효성 검증 성공 시 헤더에 액세스 토큰, 바디에 result, message, id, 토큰 전달
             HttpHeaders responseHeaders = new HttpHeaders();
             responseHeaders.set(jwtTokenProvider.ACCESS_TOKEN_NAME, refreshResult.getAccessToken());
+//            responseHeaders.set(jwtTokenProvider.REFRESH_TOKEN_NAME, refreshResult.getRefreshToken());    // 클라분들이랑 얘기 나눠보고 이거 헤더에 셋해줄지 생각해볼 정할 것.
 
             return new ResponseEntity(refreshResult, responseHeaders, HttpStatus.OK);
         }

--- a/application-module/customer/src/main/java/com/rest/api/auth/jwt/JwtTokenProvider.java
+++ b/application-module/customer/src/main/java/com/rest/api/auth/jwt/JwtTokenProvider.java
@@ -66,16 +66,17 @@ public class JwtTokenProvider {
     {
         List<String> findInfo = redisService.getListValue(refreshToken);    // 0 = providerUserId, 1 = refreshToken
         if (findInfo.get(0) == null) { // 유저 정보가 없으면 FAILED 반환
-            return new CustomerRefreshResultDto(FAIL_STRING, "No user found", null, null);
+            return new CustomerRefreshResultDto(FAIL_STRING, "No user found", null, null, null);
         }
         if (validateToken(refreshToken))  // refresh Token 유효성 검증 완료 시
         {
             UserDetails findUser = customUserDetailsService.loadUserByProviderUserId((String)findInfo.get(0));
             List<String> roles = findUser.getAuthorities().stream().map(authority -> authority.getAuthority()).collect(Collectors.toList());
             String newAccessToken = generateAccessToken((String)findInfo.get(0), roles);
-            return new CustomerRefreshResultDto(SUCCESS_STRING, "Access token refreshed", findInfo.get(0), newAccessToken);
+            String newRefreshToken = generateRefreshToken();
+            return new CustomerRefreshResultDto(SUCCESS_STRING, "Access token refreshed", findInfo.get(0), newAccessToken, newRefreshToken);
         }
-        return new CustomerRefreshResultDto(FAIL_STRING, "Refresh token expired", null, null);  // refresh Token 만료 시
+        return new CustomerRefreshResultDto(FAIL_STRING, "Refresh token expired", null, null, null);  // refresh Token 만료 시
     }
 
     public boolean validateToken(String jwtToken) { // Jwt 토큰의 유효성 + 만료일자 확인

--- a/application-module/customer/src/main/java/com/rest/api/auth/service/MobileOAuthService.java
+++ b/application-module/customer/src/main/java/com/rest/api/auth/service/MobileOAuthService.java
@@ -102,18 +102,11 @@ public class MobileOAuthService {
     }
 
     // <-------------------- Sign-in part -------------------->
-    public CustomerTokenInfoDto signInWithRefreshToken(String refreshToken) {
-        CustomerTokenInfoDto customerTokenInfoDto = new CustomerTokenInfoDto();
+    public CustomerRefreshResultDto signInWithRefreshToken(String refreshToken) {
         CustomerRefreshResultDto refreshResult = jwtTokenProvider.validateRefreshToken(refreshToken);   // refresh token 유효성 검증
         if (refreshResult.getResult().equals(jwtTokenProvider.SUCCESS_STRING)) {    // Refresh token 유효성 검증 성공 시 헤더에 액세스 토큰, 바디에 result, message, id, 토큰 전달
-            User userEntity = authUtils.getUserEntity(refreshResult.getAccessToken());
-            customerTokenInfoDto.setResult(refreshResult.getResult());
-            customerTokenInfoDto.setMessage(refreshResult.getMessage());
-            customerTokenInfoDto.setAccessToken(refreshResult.getAccessToken());
-            customerTokenInfoDto.setRefreshToken(null); // 리프레시 갱신되는 코드까지 넣으면 이 부분 수정하기
-            customerTokenInfoDto.setUserDto(modelMapper.map(userEntity, UserDto.class));
-
-            return customerTokenInfoDto;
+//            redisService.deleteKey(refreshToken);   // 일단 리프레시 토큰 새로 생성은 하는데, 기존 리프레시 토큰 삭제는 클라분들이랑 얘기되고 난 후에 작동시키든 말든 할 것.
+            return refreshResult;
         }
 
         return null;

--- a/domain-module/src/main/java/dto/auth/token/customer/CustomerRefreshResultDto.java
+++ b/domain-module/src/main/java/dto/auth/token/customer/CustomerRefreshResultDto.java
@@ -19,5 +19,6 @@ public class CustomerRefreshResultDto {
     private String providerUserId;
     @Schema(description = "갱신된 액세스 토큰")
     private String accessToken;
-
+    @Schema(description = "갱신된 리프레시 토큰")
+    private String refreshToken;
 }


### PR DESCRIPTION
## 🔍 개요
+ close #185 

## 📝 작업사항
사용자 앱의 refresh를 통한 액세스 토큰 갱신 시의 response body에서 user enttiy를 제거했습니다. 이는 클라이언트에서 리프레시 시에는 유저 엔티티를 받아오지 않아도 된다고 한 점과, 필요 없는 데이터를 위해 조회를 거치는 과정이 불필요해보였기 때문에 진행되었습니다.
또한 바뀐 dto에는 refreshToken이 추가되었습니다. 이는 클라이언트 개발자분들과 상의를 통해 기존 리프레시 시에는 refreshToken을 갱신하지 않고 accessToken만 갱신했지만, 계속적인 접속 시 refreshToken의 유효기간도 늘리는 방향도 고려해볼 만한 것 같아 우선은 dto에 추가는 해두었습니다. header에 set하는 로직, 기존에 쓰던 refreshToken은 메모리에서 삭제하는 로직 모두 구현해놨으나, 주석처리 해두었습니다. 이 방향으로의 수정이 필요없다는 판단이 내려지면 dto에서 refreshToken 삭제, 주석처리한 부분만 지우면 되어 진행에 지장은 없어 보입니다.

## 📸 스크린샷 또는 영상
1. 바뀐 DTO
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/cac298d1-5835-41ae-af1c-bfa8d066c6e4)

2. 바뀐 response body
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/b7bd436b-6963-498d-bc1c-3590305b9a77)



## 🧐 참고 사항

## 📄 Reference
[]()
