### PR TITLE
사장님 앱 - 변경 요청 시 이미지가 null값일 때의 처리 결과 수정

### DIFF
--- a/application-module/seller/src/main/java/com/rest/api/store/service/ItemService.java
+++ b/application-module/seller/src/main/java/com/rest/api/store/service/ItemService.java
@@ -96,6 +96,8 @@ public class ItemService {
         if(itemImg != null) {
             String imageURL = s3Uploader.upload(itemImg, store.getStoreName());
             updateDto.setImageURL(imageURL);
+        } else {    // 변경할 이미지를 보내지 않았을 때
+            updateDto.setImageURL(itemEntity.getImageURL());    // 기존의 이미지를 사용하도록 수정
         }
 
         // 3. 엔티티 업데이트

--- a/application-module/seller/src/main/java/com/rest/api/store/service/StoreService.java
+++ b/application-module/seller/src/main/java/com/rest/api/store/service/StoreService.java
@@ -59,6 +59,8 @@ public class StoreService {
         if(storeImg != null) {
             String imageURL = s3Uploader.upload(storeImg, store.getStoreName());
             patchDto.setStoreImageUrl(imageURL);
+        } else {    // 변경할 이미지를 보내지 않았을 때
+            patchDto.setStoreImageUrl(store.getStoreImageUrl());    // 기존의 이미지를 사용하도록 수정
         }
 
         store.modifyStore(patchDto);


### PR DESCRIPTION
## 🔍 개요
+ close #201 

## 📝 작업사항
사장님 앱에서 가게, 상품 수정에 있어 이미지 값을 null로 요청했을 때(기존 이미지 사용을 하고자 하는 경우), 이미지 삭제가 아닌 기존 이미지 사용을 하게 로직을 수정합니다.


## 📸 스크린샷 또는 영상
<img width="1092" alt="image" src="https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/cef82dc9-844a-4138-b348-1c0e81ac5d84">
표시한 부분에서 볼 수 있듯, 이미지 값이 null인 채로 요청이 들어오면 기존 엔티티에 저장돼있던 이미지의 url을 사용하도록 변경하였습니다.


## 🧐 참고 사항

## 📄 Reference
[]()
