### PR TITLE
사용자 앱 - order 전체 GET 상세 list로 수정

### DIFF
--- a/application-module/customer/src/main/java/com/rest/api/order/controller/OrderController.java
+++ b/application-module/customer/src/main/java/com/rest/api/order/controller/OrderController.java
@@ -4,7 +4,6 @@ import com.rest.api.auth.jwt.JwtTokenProvider;
 import com.rest.api.order.service.OrderService;
 import com.zupzup.untact.dto.order.customer.request.PostOrderRequestDto;
 import com.zupzup.untact.dto.order.customer.response.GetOrderDetailsDto;
-import com.zupzup.untact.dto.order.customer.response.GetOrderDto;
 import com.zupzup.untact.dto.order.customer.response.PostOrderResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -61,7 +60,7 @@ public class OrderController {
                     content = {
                             @Content(
                                     mediaType = "application/json",
-                                    array = @ArraySchema(schema = @Schema(implementation = GetOrderDto.class)))
+                                    array = @ArraySchema(schema = @Schema(implementation = GetOrderDetailsDto.class)))
                     }
             ),
             @ApiResponse(responseCode = "400", description = "요청에 필요한 헤더(액세스 토큰)가 없음",
@@ -72,7 +71,7 @@ public class OrderController {
     })
     @GetMapping("")
     public ResponseEntity orderList(@Parameter(name = "accessToken", description = "액세스 토큰", in = ParameterIn.HEADER) @RequestHeader(JwtTokenProvider.ACCESS_TOKEN_NAME) String accessToken) {
-        List<GetOrderDto> allOrderListDto = orderService.orderList(accessToken);
+        List<GetOrderDetailsDto> allOrderListDto = orderService.orderList(accessToken);
         
         return new ResponseEntity(allOrderListDto, HttpStatus.OK);
     }

--- a/application-module/customer/src/main/java/com/rest/api/order/service/OrderService.java
+++ b/application-module/customer/src/main/java/com/rest/api/order/service/OrderService.java
@@ -12,7 +12,6 @@ import com.zupzup.untact.domain.store.Store;
 import com.zupzup.untact.dto.order.OrderDto;
 import com.zupzup.untact.dto.order.customer.request.PostOrderRequestDto;
 import com.zupzup.untact.dto.order.customer.response.GetOrderDetailsDto;
-import com.zupzup.untact.dto.order.customer.response.GetOrderDto;
 import com.zupzup.untact.dto.order.customer.response.PostOrderResponseDto;
 import com.zupzup.untact.repository.FirstOrderDataRepository;
 import com.zupzup.untact.repository.OrderRepository;
@@ -88,12 +87,12 @@ public class OrderService {
     }
 
     // <-------------------- GET part -------------------->
-    public List<GetOrderDto> orderList(String accessToken) {
+    public List<GetOrderDetailsDto> orderList(String accessToken) {
         User userEntity = authUtils.getUserEntity(accessToken);
         List<Order> userOrderListEntity = orderRepository.findByUserId(userEntity.getUserId());
-        List<GetOrderDto> userOrderListDto = userOrderListEntity.stream()
+        List<GetOrderDetailsDto> userOrderListDto = userOrderListEntity.stream()
                 .filter(m -> !m.getOrderStatus().equals(OrderStatus.WITHDREW))
-                .map(m -> modelMapper.map(m, GetOrderDto.class))
+                .map(m -> modelMapper.map(m, GetOrderDetailsDto.class))
                 .collect(Collectors.toList());
 
         return userOrderListDto;


### PR DESCRIPTION
## 🔍 개요
+ close #261 

## 📝 작업사항
- 작업 내용 및 변경사항
사용자 앱의 주문 전체 조회 시 화면 상 필요한 정보만 주는 것이 아닌, 주문 상세 정보의 리스트를 반환하도록 수정합니다.

## 📸 스크린샷 또는 영상
![image](https://github.com/Team-JubJub/ZupZup_backend/assets/64959985/bd890ed9-a159-475b-a384-3e932fcb0224)
리스트의 타입과 stream에서 map의 타입을 변경하였습니다.


## 🧐 참고 사항

## 📄 Reference
[]()
